### PR TITLE
Global S2 edits

### DIFF
--- a/Project Files/Sonic 2/SonLVLObjDefs/ARZ/BreakoffPillar.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/ARZ/BreakoffPillar.cs
@@ -16,13 +16,14 @@ namespace S2ObjectDefinitions.ARZ
 			sprites[0] = new Sprite(sheet.GetSection(59, 42, 56, 56), -28, -32);
 			sprites[1] = new Sprite(sheet.GetSection(140, 80, 32, 8), -16, 24);
 			sprites[2] = new Sprite(sheet.GetSection(173, 38, 32, 37), -16, 32);
-			
-			var bitmap = new BitmapBits(1, 0x40);
-			bitmap.DrawLine(6, 0, 0x00, 0, 0x03); // LevelData.ColorWhite
-			bitmap.DrawLine(6, 0, 0x08, 0, 0x0B);
-			bitmap.DrawLine(6, 0, 0x30, 0, 0x33);
-			bitmap.DrawLine(6, 0, 0x38, 0, 0x3B);
-			debug = new Sprite(bitmap, 0, 33);
+
+			// LevelData.ColorWhite
+			BitmapBits bitmap = new BitmapBits(32, 64);
+			bitmap.DrawRectangle(6, 0, 0, 31, 36);
+			bitmap.DrawLine(6, 16, 0x08 + 32, 16, 0x0B + 32);
+			bitmap.DrawLine(6, 16, 0x10 + 32, 16, 0x13 + 32);
+			bitmap.DrawLine(6, 16, 0x18 + 32, 16, 0x1B + 32);
+			debug = new Sprite(bitmap, -16, 32);
 		}
 
 		public override ReadOnlyCollection<byte> Subtypes

--- a/Project Files/Sonic 2/SonLVLObjDefs/ARZ/FPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/ARZ/FPlatform.cs
@@ -15,10 +15,13 @@ namespace S2ObjectDefinitions.ARZ
 		{
 			sprite = new Sprite(LevelData.GetSpriteSheet("ARZ/Objects.gif").GetSection(126, 145, 64, 45), -32, -13);
 			
-			BitmapBits overlay = new BitmapBits(2, 62);
-			for (int i = 0; i < 62; i += 12)
-				overlay.DrawLine(6, 0, i, 0, i + 6); // LevelData.ColorWhite
-			debug = new Sprite(overlay, 0, 0);
+			// LevelData.ColorWhite
+			BitmapBits bitmap = new BitmapBits(1, 0x1C);
+			bitmap.DrawLine(6, 0, 0x00, 0, 0x03);
+			bitmap.DrawLine(6, 0, 0x08, 0, 0x0B);
+			bitmap.DrawLine(6, 0, 0x10, 0, 0x13);
+			bitmap.DrawLine(6, 0, 0x18, 0, 0x1B);
+			debug = new Sprite(bitmap, 0, 34);
 			
 			properties[0] = new PropertySpec("Behaviour", typeof(int), "Extended",
 				"How this Platform should act upon player contact.", null, new Dictionary<string, int>

--- a/Project Files/Sonic 2/SonLVLObjDefs/ARZ/HPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/ARZ/HPlatform.cs
@@ -17,14 +17,14 @@ namespace S2ObjectDefinitions.ARZ
 			
 			BitmapBits overlay = new BitmapBits(129, 2);
 			overlay.DrawLine(6, 0, 0, 128, 0); // LevelData.ColorWhite
-			debug = new Sprite(overlay, -64, 0);
+			debug = new Sprite(overlay, -64, 8);
 			
 			properties = new PropertySpec[1];
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Left", 0 },
-					{ "Right", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
 				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
@@ -57,7 +57,12 @@ namespace S2ObjectDefinitions.ARZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 64;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, offset, 0);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/ARZ/VPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/ARZ/VPlatform.cs
@@ -19,13 +19,13 @@ namespace S2ObjectDefinitions.ARZ
 			overlay.DrawLine(6, 0, 0, 0, 128); // LevelData.ColorWhite
 			debug = new Sprite(overlay, 0, -64);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 1) ? 1 : 0,
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 		
@@ -56,7 +56,12 @@ namespace S2ObjectDefinitions.ARZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 64;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/ARZ/VPlatform2.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/ARZ/VPlatform2.cs
@@ -19,13 +19,13 @@ namespace S2ObjectDefinitions.ARZ
 			overlay.DrawLine(6, 0, 0, 0, 64); // LevelData.ColorWhite
 			debug = new Sprite(overlay, 0, -32);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 1) ? 1 : 0,
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 		
@@ -56,7 +56,12 @@ namespace S2ObjectDefinitions.ARZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 32;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/CNZ/Elevator.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CNZ/Elevator.cs
@@ -8,22 +8,26 @@ namespace S2ObjectDefinitions.CNZ
 	class Elevator : ObjectDefinition
 	{
 		private Sprite sprite;
+		private Sprite debug;
 		private PropertySpec[] properties = new PropertySpec[2];
 
 		public override void Init(ObjectData data)
 		{
 			sprite = new Sprite(LevelData.GetSpriteSheet("CNZ/Objects.gif").GetSection(193, 34, 32, 16), -16, -8);
+			BitmapBits overlay = new BitmapBits(32, 16);
+			overlay.DrawRectangle(6, 0, 0, 31, 15); // LevelData.ColorWhite
+			debug = new Sprite(overlay, -16, -8);
 			
 			properties[0] = new PropertySpec("Distance", typeof(int), "Extended",
-				"How far the Elevator will go. Direction is determined by the Travel Direction variable.", null,
+				"How far the Elevator will go.", null,
 				(obj) => obj.PropertyValue & 0x7f,
 				(obj, value) => obj.PropertyValue = (byte)((obj.PropertyValue & ~0x7f) | (byte)((int)value)));
 			
-			properties[1] = new PropertySpec("Travel Direction", typeof(int), "Extended",
-				"Which direction the Elevator will travel in.", null, new Dictionary<string, int>
+			properties[1] = new PropertySpec("Start From", typeof(int), "Extended",
+				"Where the Elevator will start from.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 0x80 }
+					{ "Bottom", 0 },
+					{ "Top", 0x80 }
 				},
 				(obj) => obj.PropertyValue & 0x80,
 				(obj, value) => obj.PropertyValue = (byte)((obj.PropertyValue & ~0x80) | (byte)((int)value)));
@@ -61,15 +65,27 @@ namespace S2ObjectDefinitions.CNZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int dist = (obj.PropertyValue & 127) << 2;
+			if ((obj.PropertyValue & 0x80) == 0)
+			{
+				dist *= -1;
+			}
+			return new Sprite(sprite, 0, -dist);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)
 		{
 			int dist = (obj.PropertyValue & 127) << 2;
+			/*
 			BitmapBits bitmap = new BitmapBits(2, (2 * dist) + 1);
 			bitmap.DrawLine(6, 0, 0, 0, (2 * dist)); // LevelData.ColorWhite
 			return new Sprite(bitmap, 0, -dist);
+			*/
+			if ((obj.PropertyValue & 0x80) == 0)
+			{
+				dist *= -1;
+			}
+			return new Sprite(debug, 0, dist);
 		}
 	}
 }

--- a/Project Files/Sonic 2/SonLVLObjDefs/CNZ/HBlock.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CNZ/HBlock.cs
@@ -19,14 +19,14 @@ namespace S2ObjectDefinitions.CNZ
 			bitmap.DrawLine(6, 0, 0, 192, 0); // LevelData.ColorWhite
 			debug = new Sprite(bitmap, -96, 0);
 			
-			properties[0] = new PropertySpec("Starting Direction", typeof(int), "Extended",
-				"Which direction the Horizontal Block will initially travel in. Overall range is the same between both directions.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses block movement.", null, new Dictionary<string, int>
 				{
-					{ "Right", 0 },
-					{ "Left", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 0) ? 0 : 1,
-				(obj, value) => obj.PropertyValue = (byte)((int)value));
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
+				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 
 		public override ReadOnlyCollection<byte> Subtypes
@@ -56,7 +56,12 @@ namespace S2ObjectDefinitions.CNZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = -96;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, offset, 0);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/CNZ/HexBumper.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CNZ/HexBumper.cs
@@ -8,6 +8,7 @@ namespace S2ObjectDefinitions.CNZ
 	class HexBumper : ObjectDefinition
 	{
 		private Sprite img;
+		private Sprite debug;
 		private PropertySpec[] properties;
 
 		public override void Init(ObjectData data)
@@ -20,6 +21,10 @@ namespace S2ObjectDefinitions.CNZ
 			{
 				img = new Sprite(LevelData.GetSpriteSheet("MBZ/Objects.gif").GetSection(581, 343, 48, 32), -24, -16);
 			}
+
+			BitmapBits bitmap = new BitmapBits(193, 2);
+			bitmap.DrawLine(6, 0, 0, 192, 0); // LevelData.ColorWhite
+			debug = new Sprite(bitmap, -96, 0);
 			
 			properties = new PropertySpec[1];
 			properties[0] = new PropertySpec("Moving", typeof(int), "Extended",
@@ -60,6 +65,15 @@ namespace S2ObjectDefinitions.CNZ
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
 			return img;
+		}
+
+		public override Sprite GetDebugOverlay(ObjectEntry obj)
+		{
+			if (obj.PropertyValue == 1)
+			{
+				return debug;
+			}
+			return new Sprite();
 		}
 	}
 }

--- a/Project Files/Sonic 2/SonLVLObjDefs/CNZ/VBlock.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CNZ/VBlock.cs
@@ -19,14 +19,14 @@ namespace S2ObjectDefinitions.CNZ
 			bitmap.DrawLine(6, 0, 0, 0, 192); // LevelData.ColorWhite
 			debug = new Sprite(bitmap, 0, -96);
 			
-			properties[0] = new PropertySpec("Starting Direction", typeof(int), "Extended",
-				"Which direction the Vertical Block will travel in.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses block movement.", null, new Dictionary<string, int>
 				{
-					{ "Downwards", 0 },
-					{ "Upwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 0) ? 0 : 1,
-				(obj, value) => obj.PropertyValue = (byte)((obj.PropertyValue & 254) | (byte)((int)value)));
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
+				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 
 		public override ReadOnlyCollection<byte> Subtypes
@@ -56,7 +56,12 @@ namespace S2ObjectDefinitions.CNZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = -96;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/CPZ.ini
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CPZ.ini
@@ -66,7 +66,7 @@ codefile=CPZ/TubeSpring.cs
 codetype=S2ObjectDefinitions.CPZ.TubeSpring
 [CPZ/VPlatform.txt]
 codefile=CPZ/Platform.cs
-codetype=S2ObjectDefinitions.CPZ.HPlatform
+codetype=S2ObjectDefinitions.CPZ.VPlatform
 [CPZ/VPlatform2.txt]
 codefile=CPZ/Platform.cs
 codetype=S2ObjectDefinitions.CPZ.VPlatform2

--- a/Project Files/Sonic 2/SonLVLObjDefs/CPZ/BumpingPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CPZ/BumpingPlatform.cs
@@ -9,7 +9,7 @@ namespace S2ObjectDefinitions.CPZ
 	{
 		private PropertySpec[] properties = new PropertySpec[1];
 		private readonly Sprite[] sprites = new Sprite[2];
-		private readonly Sprite[] debug = new Sprite[3];
+		private readonly Sprite[] debug = new Sprite[4];
 
 		public override void Init(ObjectData data)
 		{
@@ -33,14 +33,17 @@ namespace S2ObjectDefinitions.CPZ
 
 			BitmapBits overlay = new BitmapBits(1024, 2);
 			
-			overlay.DrawLine(6, 0, 0, 512, 1); // LevelData.ColorWhite
+			overlay.DrawLine(6, 0, 0, 255, 0); // LevelData.ColorWhite
 			debug[0] = new Sprite(overlay, -128, -2);
 			
-			overlay.DrawLine(6, 0, 0, 768, 1); // LevelData.ColorWhite
+			overlay.DrawLine(6, 0, 0, 383, 0); // LevelData.ColorWhite
 			debug[1] = new Sprite(overlay, -192, -2);
 			
-			overlay.DrawLine(6, 0, 0, 1024, 1); // LevelData.ColorWhite
+			overlay.DrawLine(6, 0, 0, 511, 0); // LevelData.ColorWhite
 			debug[2] = new Sprite(overlay, -256, -2);
+
+			overlay.DrawLine(6, 0, 0, 383, 0); // LevelData.ColorWhite
+			debug[3] = new Sprite(overlay, -192, -2);
 			
 			properties[0] = new PropertySpec("Movement", typeof(int), "Extended",
 				"The way this platform moves.", null, new Dictionary<string, int>
@@ -48,7 +51,7 @@ namespace S2ObjectDefinitions.CPZ
 					{ "One platform, 256px", 0 },
 					{ "Two platforms, 384px", 1 },
 					{ "Two platforms, 512px", 2 },
-					{ "One platforms, 384px", 3 }
+					{ "One platform, 384px", 3 }
 				},
 				(obj) => obj.PropertyValue & 3,
 				(obj, value) => obj.PropertyValue = (byte)((int)value));
@@ -71,7 +74,7 @@ namespace S2ObjectDefinitions.CPZ
 				case 2:
 					return "Two platforms, 512px";
 				case 3:
-					return "Two platforms, 512px";
+					return "One platform, 384px";
 			}
 		}
 

--- a/Project Files/Sonic 2/SonLVLObjDefs/CPZ/Platform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/CPZ/Platform.cs
@@ -81,7 +81,7 @@ namespace S2ObjectDefinitions.CPZ
 				(obj, value) => obj.PropertyValue = (byte)((int)value));
 			
 			props[1] = new PropertySpec("Flip Movement", typeof(bool), "Extended",
-				"Whether or not this Platform's movement cycle should be flipped or not.", null,
+				"If this Platform's movement cycle should be flipped or not.", null,
 				(obj) => (((V4ObjectEntry)obj).Direction == RSDKv3_4.Tiles128x128.Block.Tile.Directions.FlipX),
 				(obj, value) => ((V4ObjectEntry)obj).Direction = (RSDKv3_4.Tiles128x128.Block.Tile.Directions)(((bool)value == true) ? 1 : 0));
 			

--- a/Project Files/Sonic 2/SonLVLObjDefs/EHZ/HPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/EHZ/HPlatform.cs
@@ -13,10 +13,10 @@ namespace S2ObjectDefinitions.EHZ
 		
 		public override void Init(ObjectData data)
 		{
-			int yoffset = -12;
+			int yoffset = 4;
 			if (LevelData.StageInfo.folder[LevelData.StageInfo.folder.Length-1] == '1')
 			{
-				sprite = new Sprite(LevelData.GetSpriteSheet("EHZ/Objects.gif").GetSection(127, 98, 64, 32), -32, -12);
+				sprite = new Sprite(LevelData.GetSpriteSheet("EHZ/Objects.gif").GetSection(127, 98, 64, 32), -32, -12);a
 			}
 			else
 			{
@@ -24,18 +24,15 @@ namespace S2ObjectDefinitions.EHZ
 				yoffset = -8;
 			}
 			
-			// tagging this area withLevelData.ColorWhite
-			BitmapBits bitmap = new BitmapBits(193, 33);
-			bitmap.DrawRectangle(6, 0, 0, 63, 31); // left box
-			bitmap.DrawRectangle(6, 128, 0, 63, 31); // right box
-			bitmap.DrawLine(6, 32, -yoffset, 160, -yoffset);
+			BitmapBits bitmap = new BitmapBits(193, 2);
+			bitmap.DrawLine(6, 32, 0, 160, 0);
 			debug = new Sprite(bitmap, -96, yoffset);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Left", 0 },
-					{ "Right", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
 				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
@@ -68,7 +65,12 @@ namespace S2ObjectDefinitions.EHZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 64;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, offset, 0);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/EHZ/VPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/EHZ/VPlatform.cs
@@ -13,7 +13,7 @@ namespace S2ObjectDefinitions.EHZ
 		
 		public override void Init(ObjectData data)
 		{
-			int yoffset = -12;
+			int yoffset = 4;
 			if (LevelData.StageInfo.folder[LevelData.StageInfo.folder.Length-1] == '1')
 			{
 				sprite = new Sprite(LevelData.GetSpriteSheet("EHZ/Objects.gif").GetSection(127, 98, 64, 32), -32, -12);
@@ -24,20 +24,17 @@ namespace S2ObjectDefinitions.EHZ
 				yoffset = -8;
 			}
 			
-			// tagging this area with LevelData.ColorWhite
-			BitmapBits overlay = new BitmapBits(65, 161);
-			overlay.DrawRectangle(6, 0, 0, 63, 31); // top box
-			overlay.DrawRectangle(6, 0, 128, 63, 31); // bottom box
-			overlay.DrawLine(6, 32, -yoffset, 32, -yoffset + 128); // movement line
-			debug = new Sprite(overlay, -32, -64 + yoffset);
+			BitmapBits overlay = new BitmapBits(2, 161);
+			overlay.DrawLine(6, 0, 0, 0, 128);
+			debug = new Sprite(overlay, 0, -64 + yoffset);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 1) ? 1 : 0,
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 		
@@ -68,7 +65,12 @@ namespace S2ObjectDefinitions.EHZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 64;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/EHZ/VPlatform2.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/EHZ/VPlatform2.cs
@@ -26,13 +26,13 @@ namespace S2ObjectDefinitions.EHZ
 			overlay.DrawLine(6, 0, 0, 0, 64); // LevelData.ColorWhite
 			debug = new Sprite(overlay, 0, -32);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 1) ? 1 : 0,
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 		
@@ -63,7 +63,12 @@ namespace S2ObjectDefinitions.EHZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 32;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/HTZ/HPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/HTZ/HPlatform.cs
@@ -15,18 +15,15 @@ namespace S2ObjectDefinitions.HTZ
 		{
 			sprite = new Sprite(LevelData.GetSpriteSheet("HTZ/Objects.gif").GetSection(191, 223, 64, 32), -32, -12);
 			
-			// tagging this area withLevelData.ColorWhite
-			BitmapBits bitmap = new BitmapBits(193, 33);
-			bitmap.DrawRectangle(6, 0, 0, 63, 31); // left box
-			bitmap.DrawRectangle(6, 128, 0, 63, 31); // right box
-			bitmap.DrawLine(6, 32, 12, 160, 12);
-			debug = new Sprite(bitmap, -96, -12);
+			BitmapBits bitmap = new BitmapBits(193, 2);
+			bitmap.DrawLine(6, 32, 0, 160, 0);
+			debug = new Sprite(bitmap, -96, 4);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Left", 0 },
-					{ "Right", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
 				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
@@ -59,7 +56,12 @@ namespace S2ObjectDefinitions.HTZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 64;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, offset, 0);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/HTZ/VPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/HTZ/VPlatform.cs
@@ -15,20 +15,17 @@ namespace S2ObjectDefinitions.HTZ
 		{
 			sprite = new Sprite(LevelData.GetSpriteSheet("HTZ/Objects.gif").GetSection(191, 223, 64, 32), -32, -12);
 			
-			// tagging this area with LevelData.ColorWhite
-			BitmapBits overlay = new BitmapBits(65, 161);
-			overlay.DrawRectangle(6, 0, 0, 63, 31); // top box
-			overlay.DrawRectangle(6, 0, 128, 63, 31); // bottom box
-			overlay.DrawLine(6, 32, -12, 32, -12 + 128); // movement line
-			debug = new Sprite(overlay, -32, -64 + 12);
+			BitmapBits overlay = new BitmapBits(2, 161);
+			overlay.DrawLine(6, 0, 0, 0, 128);
+			debug = new Sprite(overlay, 0, -64 + 4);
 			
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 1) ? 1 : 0,
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 		
@@ -59,7 +56,12 @@ namespace S2ObjectDefinitions.HTZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 64;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/HTZ/VPlatform2.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/HTZ/VPlatform2.cs
@@ -9,7 +9,7 @@ namespace S2ObjectDefinitions.HTZ
 	{
 		private Sprite sprite;
 		private Sprite debug;
-		private PropertySpec[] properties;
+		private PropertySpec[] properties = new PropertySpec[1];
 		
 		public override void Init(ObjectData data)
 		{
@@ -19,14 +19,13 @@ namespace S2ObjectDefinitions.HTZ
 			overlay.DrawLine(6, 0, 0, 0, 64); // LevelData.ColorWhite
 			debug = new Sprite(overlay, 0, -32);
 			
-			properties = new PropertySpec[1];
-			properties[0] = new PropertySpec("Start Direction", typeof(int), "Extended",
-				"The starting direction of this Platform.", null, new Dictionary<string, int>
+			properties[0] = new PropertySpec("Reverse", typeof(int), "Extended",
+				"Reverses platform movement.", null, new Dictionary<string, int>
 				{
-					{ "Upwards", 0 },
-					{ "Downwards", 1 }
+					{ "False", 0 },
+					{ "True", 1 }
 				},
-				(obj) => (obj.PropertyValue == 1) ? 1 : 0,
+				(obj) => ((obj.PropertyValue == 1) ? 1 : 0),
 				(obj, value) => obj.PropertyValue = (byte)(int)value);
 		}
 		
@@ -57,7 +56,12 @@ namespace S2ObjectDefinitions.HTZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int offset = 32;
+			if (obj.PropertyValue == 1)
+			{
+				offset *= -1;
+			}
+			return new Sprite(sprite, 0, offset);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)

--- a/Project Files/Sonic 2/SonLVLObjDefs/OOZ/Elevator.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/OOZ/Elevator.cs
@@ -8,12 +8,16 @@ namespace S2ObjectDefinitions.OOZ
 	class Elevator : ObjectDefinition
 	{
 		private Sprite sprite;
+		private Sprite debug;
 		private PropertySpec[] properties = new PropertySpec[2];
 
 		public override void Init(ObjectData data)
 		{
 			sprite = new Sprite(LevelData.GetSpriteSheet("OOZ/Objects.gif").GetSection(127, 1, 128, 24), -64, -12);
-			
+			BitmapBits overlay = new BitmapBits(128, 24);
+			overlay.DrawRectangle(6, 0, 0, 127, 23); // LevelData.ColorWhite
+			debug = new Sprite(overlay, -64, -12);
+
 			properties[0] = new PropertySpec("Distance", typeof(int), "Extended",
 				"How far the Elevator will go.", null,
 				(obj) => obj.PropertyValue & 0x7f,
@@ -61,15 +65,27 @@ namespace S2ObjectDefinitions.OOZ
 
 		public override Sprite GetSprite(ObjectEntry obj)
 		{
-			return sprite;
+			int dist = (obj.PropertyValue & 127) << 2;
+			if ((obj.PropertyValue & 0x80) == 0)
+			{
+				dist *= -1;
+			}
+			return new Sprite(sprite, 0, -dist + 4);
 		}
 		
 		public override Sprite GetDebugOverlay(ObjectEntry obj)
 		{
 			int dist = (obj.PropertyValue & 127) << 2;
+			/*
 			BitmapBits bitmap = new BitmapBits(2, (2 * dist) + 1);
 			bitmap.DrawLine(6, 0, 0, 0, (2 * dist)); // LevelData.ColorWhite
 			return new Sprite(bitmap, 0, -dist);
+			*/
+			if ((obj.PropertyValue & 0x80) == 0)
+			{
+				dist *= -1;
+			}
+			return new Sprite(debug, 0, dist + 4);
 		}
 	}
 }

--- a/Project Files/Sonic 2/SonLVLObjDefs/OOZ/GasPlatform.cs
+++ b/Project Files/Sonic 2/SonLVLObjDefs/OOZ/GasPlatform.cs
@@ -15,12 +15,13 @@ namespace S2ObjectDefinitions.OOZ
 		{
 			sprite = new Sprite(LevelData.GetSpriteSheet("OOZ/Objects.gif").GetSection(84, 108, 48, 12), -24, -8);
 			
-			BitmapBits overlay = new BitmapBits(2, 208);
-			overlay.DrawLine(6, 0, 0, 0, 207); // LevelData.ColorWhite
-			debug[0] = new Sprite(overlay, 0, -207);
+			BitmapBits overlay = new BitmapBits(11, 208);
+			overlay.DrawLine(6, 5, 0, 5, 198); // LevelData.ColorWhite
+			overlay.DrawLine(6, 0, 0, 10, 0);
+			debug[0] = new Sprite(overlay, -5, -207);
 			
 			overlay = new BitmapBits(2, 121);
-			overlay.DrawLine(6, 0, 0, 0, 120);
+			overlay.DrawLine(6, 0, 0, 0, 111);
 			debug[1] = new Sprite(overlay, 0, -120);
 			
 			


### PR DESCRIPTION
- Made all moving platforms and the CNZ Blocks follow the same style as the CPZ platforms (i.e. a line showing the movement range and the sprite at the position it starts in-game)
- Made the OOZ and CNZ Elevators show their sprite at their starting position and an outline at their ending position, as opposed to showing a movement line
- Made the ARZ Breakoff Pillar more visually distinct from the Falling Pillar
- Gave the CNZ Hex Bumper a movement line
- Tweaked the OOZ Gas Platform line
- Fixed CPZ Bumping Platform