### PR TITLE
Create SonLVL-RSDK Autobuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build SonLVL-RSDK
+on: [push, workflow_dispatch]
+jobs:
+   build:
+     runs-on: windows-latest
+     steps:
+       - name: Checkout repository 
+         uses: actions/checkout@v4
+       - name: Setup MSBuild
+         uses: microsoft/setup-msbuild@v2
+       - name: Build
+         run: |
+          msbuild SonLVL-RSDK.sln /p:Configuration=Release
+       - name: Move artifacts
+         run: |
+           mkdir artifacts
+           Move-Item -Path ".\SonLVL\bin\Release\*" -Destination "./artifacts" -Exclude "artifacts"
+       - name: Upload artifacts
+         uses: actions/upload-artifact@v4
+         with:
+           name: SonLVL-RSDK
+           path: artifacts
+    


### PR DESCRIPTION
Creates a workflow file that allows for SonLVL-RSDK to be built either when you push to the repo or when you manually run it from the Actions tab in GitHub.